### PR TITLE
Ignore lgr 0.5.0 rawMsg property in json log

### DIFF
--- a/R/log.R
+++ b/R/log.R
@@ -30,7 +30,7 @@ LogLayoutJson <- R6::R6Class(
 
             custom_names = setdiff(
                 names(event$values),
-                c("msg", "timestamp", "level", "caller", "logger")
+                c("msg", "timestamp", "level", "caller", "logger", "rawMsg")
             )
 
             log_fields = c(default_fields, event$values[custom_names])


### PR DESCRIPTION
The next lgr version introduces a custom rawMsg property that is not expected by your custom json layout. It's a simple fix :)