### PR TITLE
53 replace keepout flag by general tagging

### DIFF
--- a/R/aliases.R
+++ b/R/aliases.R
@@ -24,11 +24,10 @@
 #' names. By default, this is the name of the step, which comes in
 #' handy when the pipeline is copy-appended multiple times to keep
 #' the results of the same function/step grouped at one place.
-#' @param keepOut `logical` if `FALSE` (default) the output of the
-#' step is not collected when calling [pipe_collect_out()] after the pipeline
-#' run. This option is used to only keep the results that matter
-#' and skip intermediate results that are not needed. See also
-#' function [pipe_collect_out()] for more details.
+#' @param tags `character` Optional tags associated with the step.
+#' Tags can be used later to select certain parts of a pipeline,
+#' for example, to collect output from or skip steps of a certain tag.
+#'
 #' @return returns the `Pipeline` object invisibly
 #' @examples
 #' # Add steps with lambda functions
@@ -65,7 +64,7 @@ pipe_add <- function(
     params = list(),
     description = "",
     group = step,
-    keepOut = FALSE
+    tags = character()
 ) {
     pip$add(
         step = step,
@@ -73,7 +72,7 @@ pipe_add <- function(
         params = params,
         description = description,
         group = group,
-        keepOut = keepOut
+        tags = tags
     )
 
     if (is.function(fun)) {
@@ -851,20 +850,19 @@ pipe_rename_step <- function(pip, from, to)
 #' names. By default, this is the name of the step, which comes in
 #' handy when the pipeline is copy-appended multiple times to keep
 #' the results of the same function/step grouped at one place.
-#' @param keepOut `logical` if `FALSE` (default) the output of the
-#' step is not collected when calling [pipe_collect_out()] after the
-#' pipeline run. This option is used to only keep the results that matter
-#' and skip intermediate results that are not needed. See also
-#' function [pipe_collect_out()] for more details.
+#' @param tags `character` Optional tags associated with the step.
+#' Tags can be used later to select certain parts of a pipeline,
+#' for example, to collect output from or skip steps of a certain tag.
+#'
 #' @return returns the `Pipeline` object invisibly
 #' @seealso [pipe_add()]
 #' @examples
 #' p <- pipe_new("pipe", data = 1)
 #' pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 #' pipe_add(p, "add2", \(x = ~data, y = 2) x + y)
-#' pipe_add(p, "mult", \(x = 1, y = 2) x * y, keepOut = TRUE)
+#' pipe_add(p, "mult", \(x = 1, y = 2) x * y)
 #' pipe_run(p) |> pipe_collect_out()
-#' pipe_replace_step(p, "mult", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+#' pipe_replace_step(p, "mult", \(x = ~add1, y = ~add2) x * y)
 #' pipe_run(p) |> pipe_collect_out()
 #' try(pipe_replace_step(p, "foo", \(x = 1) x))   # step 'foo' does not exist
 #' @export
@@ -875,7 +873,7 @@ pipe_replace_step <- function(
     params = list(),
     description = "",
     group = step,
-    keepOut = FALSE
+    tags = character()
 ) {
     pip$replace_step(
         step = step,
@@ -883,7 +881,7 @@ pipe_replace_step <- function(
         params = params,
         description = description,
         group = group,
-        keepOut = keepOut
+        tags = tags
     )
 
     if (is.function(fun)) {
@@ -940,7 +938,7 @@ pipe_reset <- function(pip)
 #' p <- pipe_new("pipe", data = 1)
 #' pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 #' pipe_add(p, "add2", \(x = ~add1, z = 2) x + z)
-#' pipe_add(p, "final", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+#' pipe_add(p, "final", \(x = ~add1, y = ~add2) x * y)
 #' p |> pipe_run() |> pipe_collect_out()
 
 #' pipe_set_params(p, list(z = 4))  # outdates steps add2 and final
@@ -954,7 +952,7 @@ pipe_reset <- function(pip)
 #' pipe_add(p, "new_pipe", \(x = ~add1) {
 #'     p2 <- pipe_new("new_pipe", data = x)
 #'     pipe_add(p2, "add1", \(x = ~data) x + 1)
-#'     pipe_add(p2, "add2", \(x = ~add1) x + 2, keepOut = TRUE)
+#'     pipe_add(p2, "add2", \(x = ~add1) x + 2)
 #'   }
 #' )
 #' p |> pipe_run() |> pipe_collect_out()
@@ -1028,7 +1026,7 @@ pipe_run_step <- function(
 #' @return returns the `Pipeline` object invisibly
 #' @examples
 #' p <- pipe_new("pipe", data = 1)
-#' pipe_add(p, "add1", \(x = ~data, y = 1) x + y, keepOut = TRUE)
+#' pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 #' p |> pipe_run() |> pipe_collect_out()
 #'
 #' pipe_set_data(p, 3)

--- a/bench/pipeline-run.Rmd
+++ b/bench/pipeline-run.Rmd
@@ -41,7 +41,7 @@ create_linear_pipeline <- function(n = 100) {
     sapply(seq_len(n), function(i) {
         pip$add(step = as.character(i), function(data = ~-1) data + 1)
     })
-    pip$add("output", function(data = ~-1) data, keepOut = TRUE)
+    pip$add("output", function(data = ~-1) data)
     pip
 }
 ```

--- a/man/Pipeline.Rd
+++ b/man/Pipeline.Rd
@@ -420,9 +420,9 @@ p
 p <- Pipeline$new("pipe", data = 1)
 p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("add2", \(x = ~data, y = 2) x + y)
-p$add("mult", \(x = 1, y = 2) x * y, keepOut = TRUE)
+p$add("mult", \(x = 1, y = 2) x * y)
 p$run()$collect_out()
-p$replace_step("mult", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+p$replace_step("mult", \(x = ~add1, y = ~add2) x * y)
 p$run()$collect_out()
 try(p$replace_step("foo", \(x = 1) x))   # step 'foo' does not exist
 
@@ -446,11 +446,11 @@ p
 p <- Pipeline$new("pipe", data = 1)
 p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("add2", \(x = ~add1, z = 2) x + z)
-p$add("final", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+p$add("final", \(x = ~add1, y = ~add2) x * y)
 p$run()$collect_out()
 p$set_params(list(z = 4))  # outdates steps add2 and final
 p
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 p
 
 # Recursive pipeline
@@ -459,10 +459,10 @@ p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("new_pipe", \(x = ~add1) {
     pp <- Pipeline$new("new_pipe", data = x)
     pp$add("add1", \(x = ~data) x + 1)
-    pp$add("add2", \(x = ~add1) x + 2, keepOut = TRUE)
+    pp$add("add2", \(x = ~add1) x + 2)
     }
 )
-p$run(recursive = TRUE)$collect_out()
+p$run(recursive = TRUE)$collect_out() |> str()
 
 # Run pipeline with progress bar
 p <- Pipeline$new("pipe", data = 1)
@@ -492,7 +492,7 @@ p$run_step("mult", upstream = TRUE)
 ## ------------------------------------------------
 
 p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = ~data, y = 1) x + y, keepOut = TRUE)
+p$add("add1", \(x = ~data, y = 1) x + y)
 p$run()$collect_out()
 p$set_data(3)
 p$run()$collect_out()
@@ -530,27 +530,27 @@ try(p$set_params_at_step("add1", list(foo = 3))) # foo not defined
 ## ------------------------------------------------
 
 p <- Pipeline$new("pipe", data = 15)
-p$add("f1", \(data = ~data, x = 1) data + x, keepOut = TRUE)
+p$add("f1", \(data = ~data, x = 1) data + x)
 p$add("log2", \(x = ~f1) log2(x), group = "prep")
 p$add("sqrt", \(x = ~log2) sqrt(x), group = "prep")
-p$add("final",  \(x = ~sqrt, y = ~f1) x + y, keepOut = TRUE)
-p$run()$collect_out()
+p$add("final",  \(x = ~sqrt, y = ~f1) x + y)
+p$run()$collect_out() |> str()
 
 p$set_params_at_step("f1", list(x = 5))$skip_group("prep")
 p$run()$collect_out()
-p$unskip_group("prep")$run()$collect_out()
+p$unskip_group("prep")$run()$collect_out() |> str()
 
 ## ------------------------------------------------
 ## Method `Pipeline$skip_step`
 ## ------------------------------------------------
 
 p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = 2, data = ~data) x + data, keepOut = TRUE)
-p$add("add2", \(x = 2, data = ~add1) x + data, keepOut = TRUE)
-p$run()$collect_out()
+p$add("add1", \(x = 2, data = ~data) x + data)
+p$add("add2", \(x = 2, data = ~add1) x + data)
+p$run()$collect_out() |> str()
 
 p$skip_step("add1")$set_params(list(x = 3))
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 
 ## ------------------------------------------------
 ## Method `Pipeline$split`
@@ -583,29 +583,29 @@ p$get_params()
 ## ------------------------------------------------
 
 p <- Pipeline$new("pipe", data = 15)
-p$add("f1", \(data = ~data, x = 1) data + x, keepOut = TRUE)
+p$add("f1", \(data = ~data, x = 1) data + x)
 p$add("log2", \(x = ~f1) log2(x), group = "prep")
 p$add("sqrt", \(x = ~log2) sqrt(x), group = "prep")
-p$add("final",  \(x = ~sqrt, y = ~f1) x + y, keepOut = TRUE)
-p$run()$collect_out()
+p$add("final",  \(x = ~sqrt, y = ~f1) x + y)
+p$run()$collect_out() |> str()
 
 p$set_params_at_step("f1", list(x = 5))$skip_group("prep")
-p$run()$collect_out()
-p$unskip_group("prep")$run()$collect_out()
+p$run()$collect_out() |> str()
+p$unskip_group("prep")$run()$collect_out() |> str()
 
 ## ------------------------------------------------
 ## Method `Pipeline$unskip_step`
 ## ------------------------------------------------
 
 p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = 2, data = ~data) x + data, keepOut = TRUE)
-p$add("add2", \(x = 2, data = ~add1) x + data, keepOut = TRUE)
-p$run()$collect_out()
+p$add("add1", \(x = 2, data = ~data) x + data)
+p$add("add2", \(x = 2, data = ~add1) x + data)
+p$run()$collect_out() |> str()
 
 p$skip_step("add1")$set_params(list(x = 3))
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 
-p$unskip_step("add1")$run()$collect_out()
+p$unskip_step("add1")$run()$collect_out() |> str()
 }
 \author{
 Roman Pahl
@@ -736,7 +736,7 @@ Add pipeline step
   params = list(),
   description = "",
   group = step,
-  keepOut = FALSE
+  tags = character(0)
 )}\if{html}{\out{</div>}}
 }
 
@@ -764,11 +764,9 @@ names. By default, this is the name of the step, which comes in
 handy when the pipeline is copy-appended multiple times to keep
 the results of the same function/step grouped at one place.}
 
-\item{\code{keepOut}}{\code{logical} if \code{FALSE} (default) the output of the
-step is not collected when calling \code{collect_out} after the pipeline
-run. This option is used to only keep the results that matter
-and skip intermediate results that are not needed. See also
-function \code{collect_out} for more details.}
+\item{\code{tags}}{\code{character} Optional tags associated with the step.
+Tags can be used later to select certain parts of a pipeline,
+for example, to collect output from or skip steps of a certain tag.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1835,7 +1833,7 @@ Replaces an existing pipeline step.
   params = list(),
   description = "",
   group = step,
-  keepOut = FALSE
+  tags = character(0)
 )}\if{html}{\out{</div>}}
 }
 
@@ -1860,9 +1858,9 @@ for example, comes in handy when the pipeline is copy-appended
 multiple times to keep the results of the same function/step at one
 place.}
 
-\item{\code{keepOut}}{\code{logical} if \code{FALSE} the output of the function will
-be cleaned at the end of the whole pipeline execution. This option
-is used to only keep the results that matter.}
+\item{\code{tags}}{\code{character} Optional tags associated with the step.
+Tags can be used later to select certain parts of a pipeline,
+for example, to collect output from or skip steps of a certain tag.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1874,9 +1872,9 @@ the \code{Pipeline} object invisibly
 \preformatted{p <- Pipeline$new("pipe", data = 1)
 p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("add2", \(x = ~data, y = 2) x + y)
-p$add("mult", \(x = 1, y = 2) x * y, keepOut = TRUE)
+p$add("mult", \(x = 1, y = 2) x * y)
 p$run()$collect_out()
-p$replace_step("mult", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+p$replace_step("mult", \(x = ~add1, y = ~add2) x * y)
 p$run()$collect_out()
 try(p$replace_step("foo", \(x = 1) x))   # step 'foo' does not exist
 }
@@ -1953,11 +1951,11 @@ returns the \code{Pipeline} object invisibly
 p <- Pipeline$new("pipe", data = 1)
 p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("add2", \(x = ~add1, z = 2) x + z)
-p$add("final", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+p$add("final", \(x = ~add1, y = ~add2) x * y)
 p$run()$collect_out()
 p$set_params(list(z = 4))  # outdates steps add2 and final
 p
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 p
 
 # Recursive pipeline
@@ -1966,10 +1964,10 @@ p$add("add1", \(x = ~data, y = 1) x + y)
 p$add("new_pipe", \(x = ~add1) {
     pp <- Pipeline$new("new_pipe", data = x)
     pp$add("add1", \(x = ~data) x + 1)
-    pp$add("add2", \(x = ~add1) x + 2, keepOut = TRUE)
+    pp$add("add2", \(x = ~add1) x + 2)
     }
 )
-p$run(recursive = TRUE)$collect_out()
+p$run(recursive = TRUE)$collect_out() |> str()
 
 # Run pipeline with progress bar
 p <- Pipeline$new("pipe", data = 1)
@@ -2032,7 +2030,7 @@ p$run_step("mult", upstream = TRUE)
 \if{html}{\out{<a id="method-Pipeline-set_data"></a>}}
 \if{latex}{\out{\hypertarget{method-Pipeline-set_data}{}}}
 \subsection{Method \code{set_data()}}{
-Set data in first step of pipeline.
+Convenience function to set data in first step of pipeline.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Pipeline$set_data(data)}\if{html}{\out{</div>}}
 }
@@ -2050,7 +2048,7 @@ returns the \code{Pipeline} object invisibly
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = ~data, y = 1) x + y, keepOut = TRUE)
+p$add("add1", \(x = ~data, y = 1) x + y)
 p$run()$collect_out()
 p$set_data(3)
 p$run()$collect_out()
@@ -2168,15 +2166,15 @@ the \code{Pipeline} object invisibly
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{p <- Pipeline$new("pipe", data = 15)
-p$add("f1", \(data = ~data, x = 1) data + x, keepOut = TRUE)
+p$add("f1", \(data = ~data, x = 1) data + x)
 p$add("log2", \(x = ~f1) log2(x), group = "prep")
 p$add("sqrt", \(x = ~log2) sqrt(x), group = "prep")
-p$add("final",  \(x = ~sqrt, y = ~f1) x + y, keepOut = TRUE)
-p$run()$collect_out()
+p$add("final",  \(x = ~sqrt, y = ~f1) x + y)
+p$run()$collect_out() |> str()
 
 p$set_params_at_step("f1", list(x = 5))$skip_group("prep")
 p$run()$collect_out()
-p$unskip_group("prep")$run()$collect_out()
+p$unskip_group("prep")$run()$collect_out() |> str()
 }
 \if{html}{\out{</div>}}
 
@@ -2211,12 +2209,12 @@ the \code{Pipeline} object invisibly
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = 2, data = ~data) x + data, keepOut = TRUE)
-p$add("add2", \(x = 2, data = ~add1) x + data, keepOut = TRUE)
-p$run()$collect_out()
+p$add("add1", \(x = 2, data = ~data) x + data)
+p$add("add2", \(x = 2, data = ~add1) x + data)
+p$run()$collect_out() |> str()
 
 p$skip_step("add1")$set_params(list(x = 3))
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 }
 \if{html}{\out{</div>}}
 
@@ -2311,15 +2309,15 @@ the \code{Pipeline} object invisibly
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{p <- Pipeline$new("pipe", data = 15)
-p$add("f1", \(data = ~data, x = 1) data + x, keepOut = TRUE)
+p$add("f1", \(data = ~data, x = 1) data + x)
 p$add("log2", \(x = ~f1) log2(x), group = "prep")
 p$add("sqrt", \(x = ~log2) sqrt(x), group = "prep")
-p$add("final",  \(x = ~sqrt, y = ~f1) x + y, keepOut = TRUE)
-p$run()$collect_out()
+p$add("final",  \(x = ~sqrt, y = ~f1) x + y)
+p$run()$collect_out() |> str()
 
 p$set_params_at_step("f1", list(x = 5))$skip_group("prep")
-p$run()$collect_out()
-p$unskip_group("prep")$run()$collect_out()
+p$run()$collect_out() |> str()
+p$unskip_group("prep")$run()$collect_out() |> str()
 }
 \if{html}{\out{</div>}}
 
@@ -2349,14 +2347,14 @@ the \code{Pipeline} object invisibly
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{p <- Pipeline$new("pipe", data = 1)
-p$add("add1", \(x = 2, data = ~data) x + data, keepOut = TRUE)
-p$add("add2", \(x = 2, data = ~add1) x + data, keepOut = TRUE)
-p$run()$collect_out()
+p$add("add1", \(x = 2, data = ~data) x + data)
+p$add("add2", \(x = 2, data = ~add1) x + data)
+p$run()$collect_out() |> str()
 
 p$skip_step("add1")$set_params(list(x = 3))
-p$run()$collect_out()
+p$run()$collect_out() |> str()
 
-p$unskip_step("add1")$run()$collect_out()
+p$unskip_step("add1")$run()$collect_out() |> str()
 }
 \if{html}{\out{</div>}}
 

--- a/man/pipe_add.Rd
+++ b/man/pipe_add.Rd
@@ -11,7 +11,7 @@ pipe_add(
   params = list(),
   description = "",
   group = step,
-  keepOut = FALSE
+  tags = character()
 )
 }
 \arguments{
@@ -38,11 +38,9 @@ names. By default, this is the name of the step, which comes in
 handy when the pipeline is copy-appended multiple times to keep
 the results of the same function/step grouped at one place.}
 
-\item{keepOut}{\code{logical} if \code{FALSE} (default) the output of the
-step is not collected when calling \code{\link[=pipe_collect_out]{pipe_collect_out()}} after the pipeline
-run. This option is used to only keep the results that matter
-and skip intermediate results that are not needed. See also
-function \code{\link[=pipe_collect_out]{pipe_collect_out()}} for more details.}
+\item{tags}{\code{character} Optional tags associated with the step.
+Tags can be used later to select certain parts of a pipeline,
+for example, to collect output from or skip steps of a certain tag.}
 }
 \value{
 returns the \code{Pipeline} object invisibly

--- a/man/pipe_replace_step.Rd
+++ b/man/pipe_replace_step.Rd
@@ -11,7 +11,7 @@ pipe_replace_step(
   params = list(),
   description = "",
   group = step,
-  keepOut = FALSE
+  tags = character()
 )
 }
 \arguments{
@@ -38,11 +38,9 @@ names. By default, this is the name of the step, which comes in
 handy when the pipeline is copy-appended multiple times to keep
 the results of the same function/step grouped at one place.}
 
-\item{keepOut}{\code{logical} if \code{FALSE} (default) the output of the
-step is not collected when calling \code{\link[=pipe_collect_out]{pipe_collect_out()}} after the
-pipeline run. This option is used to only keep the results that matter
-and skip intermediate results that are not needed. See also
-function \code{\link[=pipe_collect_out]{pipe_collect_out()}} for more details.}
+\item{tags}{\code{character} Optional tags associated with the step.
+Tags can be used later to select certain parts of a pipeline,
+for example, to collect output from or skip steps of a certain tag.}
 }
 \value{
 returns the \code{Pipeline} object invisibly
@@ -54,9 +52,9 @@ Replaces an existing pipeline step.
 p <- pipe_new("pipe", data = 1)
 pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 pipe_add(p, "add2", \(x = ~data, y = 2) x + y)
-pipe_add(p, "mult", \(x = 1, y = 2) x * y, keepOut = TRUE)
+pipe_add(p, "mult", \(x = 1, y = 2) x * y)
 pipe_run(p) |> pipe_collect_out()
-pipe_replace_step(p, "mult", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+pipe_replace_step(p, "mult", \(x = ~add1, y = ~add2) x * y)
 pipe_run(p) |> pipe_collect_out()
 try(pipe_replace_step(p, "foo", \(x = 1) x))   # step 'foo' does not exist
 }

--- a/man/pipe_run.Rd
+++ b/man/pipe_run.Rd
@@ -36,7 +36,7 @@ Runs all new and/or outdated pipeline steps.
 p <- pipe_new("pipe", data = 1)
 pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 pipe_add(p, "add2", \(x = ~add1, z = 2) x + z)
-pipe_add(p, "final", \(x = ~add1, y = ~add2) x * y, keepOut = TRUE)
+pipe_add(p, "final", \(x = ~add1, y = ~add2) x * y)
 p |> pipe_run() |> pipe_collect_out()
 pipe_set_params(p, list(z = 4))  # outdates steps add2 and final
 p
@@ -49,7 +49,7 @@ pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 pipe_add(p, "new_pipe", \(x = ~add1) {
     p2 <- pipe_new("new_pipe", data = x)
     pipe_add(p2, "add1", \(x = ~data) x + 1)
-    pipe_add(p2, "add2", \(x = ~add1) x + 2, keepOut = TRUE)
+    pipe_add(p2, "add2", \(x = ~add1) x + 2)
   }
 )
 p |> pipe_run() |> pipe_collect_out()

--- a/man/pipe_set_data.Rd
+++ b/man/pipe_set_data.Rd
@@ -19,7 +19,7 @@ Set data in first step of pipeline.
 }
 \examples{
 p <- pipe_new("pipe", data = 1)
-pipe_add(p, "add1", \(x = ~data, y = 1) x + y, keepOut = TRUE)
+pipe_add(p, "add1", \(x = ~data, y = 1) x + y)
 p |> pipe_run() |> pipe_collect_out()
 
 pipe_set_data(p, 3)

--- a/tests/testthat/test_aliases.R
+++ b/tests/testthat/test_aliases.R
@@ -212,13 +212,13 @@ describe("pipe_add",
         )
     })
 
-    test_that("keepOut must be logical",
+    test_that("tags must be character vector",
     {
         pip <- pipe_new("pipe")
 
         expect_error(
-            pipe_add(pip, "step1", fun = \() 1, keepOut = 1),
-            "is.logical(keepOut) is not TRUE",
+            pipe_add(pip, "step1", fun = \() 1, tags = 1),
+            "is.character(tags) is not TRUE",
             fixed = TRUE
         )
     })
@@ -254,12 +254,12 @@ describe("pipe_add",
     {
         pip <- pipe_new("pipe1")
         pipe_add(pip, "f1", \(a = 5) a)
-        pipe_add(pip, "f2", \(x = ~-1) 2*x, keepOut = TRUE)
+        pipe_add(pip, "f2", \(x = ~-1) 2*x)
 
         out = pipe_run(pip, ) |> pipe_collect_out()
         expect_equal(out[["f2"]][[1]], 10)
 
-        pipe_add(pip, "f3", \(x = ~-1, a = ~-2) x + a, keepOut = TRUE)
+        pipe_add(pip, "f3", \(x = ~-1, a = ~-2) x + a)
         out = pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["f3"]][[1]], 10 + 5)
     })
@@ -282,11 +282,10 @@ describe("pipe_add",
         data <- 9
         pip <- pipe_new("pipe1", data = data)
 
-        pipe_add(pip, "f1", \(data = ~data) data, keepOut = TRUE)
+        pipe_add(pip, "f1", \(data = ~data) data)
         a <- 1
         pipe_add(pip, "f2", \(a, b) a + b,
-            params = list(a = a, b = ~f1),
-            keepOut = TRUE
+            params = list(a = a, b = ~f1)
         )
 
         expect_equal(
@@ -317,7 +316,7 @@ describe("pipe_add",
         pip <- pipe_new("pipe", data = v)
 
         params <- list(x = ~data, na.rm = TRUE)
-        pipe_add(pip, "mean", fun = foo, params = params, keepOut = TRUE)
+        pipe_add(pip, "mean", fun = foo, params = params)
 
         out <- pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["mean"]], mean(v, na.rm = TRUE))
@@ -383,12 +382,12 @@ describe("pipe_append",
         unless tryAutofixNames is FALSE",
     {
         pip1 <- pipe_new("pipe1", data = 1) |>
-            pipe_add("f1", \(a = 1) a, keepOut = TRUE) |>
+            pipe_add("f1", \(a = 1) a) |>
             pipe_add("f2", \(b = ~f1) b)
 
         pip2 <- pipe_new("pipe2") |>
             pipe_add("f1", \(a = 10) a) |>
-            pipe_add("f2", \(b = ~f1) b, keepOut = TRUE)
+            pipe_add("f2", \(b = ~f1) b)
 
         expect_error(
             pip1 |> pipe_append(pip2, tryAutofixNames = FALSE),
@@ -571,8 +570,8 @@ describe("pipe_collect_out",
     test_that("output is ordered in the order of steps",
     {
         pip <- pipe_new("pipe") |>
-            pipe_add("f2", \(a = 1) a, keepOut = TRUE) |>
-            pipe_add("f1", \(b = 2) b, keepOut = TRUE)
+            pipe_add("f2", \(a = 1) a) |>
+            pipe_add("f1", \(b = 2) b)
 
         out <- pipe_run(pip) |> pipe_collect_out()
         expect_equal(names(out), c("data", "f2", "f1"))
@@ -917,12 +916,11 @@ describe("pipe_get_params",
     test_that("parameters can be retrieved",
     {
         pip <- pipe_new("pipe1") |>
-            pipe_add("f1", \(a = 1) a, keepOut = TRUE) |>
+            pipe_add("f1", \(a = 1) a) |>
             pipe_add("f2", \(a, b = ~f1) a + b,
-                params = list(a = 8),
-                keepOut = TRUE
+                params = list(a = 8)
             ) |>
-            pipe_add("f3", \(a = ~f2, b = 3) a + b, keepOut = TRUE)
+            pipe_add("f3", \(a = ~f2, b = 3) a + b)
 
         p <- pipe_get_params(pip)
         expect_equal(
@@ -1694,14 +1692,14 @@ describe("pipe_replace_step",
         )
     })
 
-    test_that("keepOut must be logical",
+    test_that("tags must be character vector",
     {
         pip <- pipe_new("pipe") |>
             pipe_add("step1", \(a = 1) a)
 
         expect_error(
-            pipe_replace_step(pip, "step1", fun =\() 1, keepOut = 1),
-            "is.logical(keepOut) is not TRUE",
+            pipe_replace_step(pip, "step1", fun =\() 1, tags = 1),
+            "is.character(tags) is not TRUE",
             fixed = TRUE
         )
     })
@@ -1710,7 +1708,7 @@ describe("pipe_replace_step",
     {
 
         pip <- pipe_new("pipe1") |>
-            pipe_add("f1", \(x = 3) x, keepOut = TRUE)
+            pipe_add("f1", \(x = 3) x)
 
         out = unname(unlist(pipe_run(pip) |> pipe_collect_out()))
         expect_equal(out, 3)
@@ -1721,7 +1719,7 @@ describe("pipe_replace_step",
         assign(".my_func", .my_func, envir = globalenv())
         on.exit(rm(".my_func", envir = globalenv()))
 
-        pipe_replace_step(pip, "f1", fun = ".my_func", keepOut = TRUE)
+        pipe_replace_step(pip, "f1", fun = ".my_func")
 
         out = unname(unlist(pipe_run(pip) |> pipe_collect_out()))
         expect_equal(out, 6)
@@ -1732,7 +1730,7 @@ describe("pipe_replace_step",
     {
 
         pip <- pipe_new("pipe1") |>
-            pipe_add("f1", \(x = 1:3) x, keepOut = TRUE)
+            pipe_add("f1", \(x = 1:3) x)
 
         .my_func <-\(x = 3) {
             2 * x
@@ -1745,7 +1743,7 @@ describe("pipe_replace_step",
             "f1",
             fun = ".my_func",
             params = list(x = 10),
-            keepOut = TRUE
+            tags = c("tag1", "tag2")
         )
 
         out = unname(unlist(pipe_run(pip) |> pipe_collect_out()))
@@ -1757,7 +1755,7 @@ describe("pipe_replace_step",
         pip <- pipe_new("pipe1") |>
             pipe_add("f1", \(a = 1) a) |>
             pipe_add("f2", \(b = 2) b) |>
-            pipe_add("f3", \(c = ~f2) c, keepOut = TRUE)
+            pipe_add("f3", \(c = ~f2) c)
 
         expect_error(pipe_replace_step(pip, "non-existent", \(z = 4) z))
     })
@@ -1769,7 +1767,7 @@ describe("pipe_replace_step",
         pip <- pipe_new("pipe1") |>
             pipe_add("f1", \(a = 1) a) |>
             pipe_add("f2", \(b = 2) b) |>
-            pipe_add("f3", \(c = ~f2) c, keepOut = TRUE)
+            pipe_add("f3", \(c = ~f2) c)
 
         expect_error(
             pipe_replace_step(pip, "f2", \(z = ~foo) z),
@@ -1793,8 +1791,8 @@ describe("pipe_replace_step",
         pip <- pipe_new("pipe1") |>
             pipe_add("f1", \(a = 1) a) |>
             pipe_add("f2", \(a = 2) a) |>
-            pipe_add("f3", \(a = ~f2) a, keepOut = TRUE) |>
-            pipe_add("f4", \(a = ~f3) a, keepOut = TRUE)
+            pipe_add("f3", \(a = ~f2) a) |>
+            pipe_add("f4", \(a = ~f3) a)
 
         pipe_run(pip)
 
@@ -1892,7 +1890,7 @@ describe("pipe_run",
         resultList = list(foo = 1)
 
         pip <- pipe_new("pipe") |>
-            pipe_add("f1", \() resultList, keepOut = TRUE)
+            pipe_add("f1", \() resultList)
 
         out = pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["f1"]], resultList)
@@ -1901,7 +1899,7 @@ describe("pipe_run",
         resultList = list(foo = 1, bar = 2)
 
         pip <- pipe_new("pipe") |>
-            pipe_add("f1", \() resultList, keepOut = TRUE)
+            pipe_add("f1", \() resultList)
 
         out = pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["f1"]], resultList)
@@ -1916,10 +1914,8 @@ describe("pipe_run",
         bar <-\(a, b) a + b
 
         a <- 5
-        pipe_add(pip, "f1", foo, params = list(a = a), keepOut = TRUE)
-        pipe_add(
-            pip, "f2", bar, params = list(a = ~data, b = ~f1), keepOut = TRUE
-        )
+        pipe_add(pip, "f1", foo, params = list(a = a))
+        pipe_add(pip, "f2", bar, params = list(a = ~data, b = ~f1))
 
         pipe_run(pip)
 
@@ -1952,7 +1948,7 @@ describe("pipe_run",
         "can handle 'NULL' results",
     {
         pip <- pipe_new("pipe", data = 1) |>
-            pipe_add("f1", \(x = ~data) x, keepOut = TRUE)
+            pipe_add("f1", \(x = ~data) x)
 
         out <- pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["f1"]], 1)
@@ -1971,9 +1967,7 @@ describe("pipe_run",
                 fun =\(data = 10) {
                     pip <- pipe_new("2nd pipe", data = data) |>
                         pipe_add("step1", \(x = ~data) x) |>
-                        pipe_add("step2", \(x = ~step1) {
-                            2 * x
-                        }, keepOut = TRUE)
+                        pipe_add("step2", \(x = ~step1) 2 * x)
                 }
             )
 
@@ -2233,7 +2227,7 @@ describe("pipe_run_step",
         "updates the timestamp of the run steps",
     {
         pip <- pipe_new("pipe", data = 1) |>
-            pipe_add("f1", \(x = ~data) x, keepOut = TRUE)
+            pipe_add("f1", \(x = ~data) x)
 
         before <- pip$pipeline[["time"]]
         Sys.sleep(1)
@@ -2249,7 +2243,7 @@ describe("pipe_run_step",
         "updates the state of the run steps",
     {
         pip <- pipe_new("pipe", data = 1) |>
-            pipe_add("f1", \(x = ~data) x, keepOut = TRUE)
+            pipe_add("f1", \(x = ~data) x)
 
         before <- pip$pipeline[["state"]]
         pipe_run_step(pip, "f1", upstream = FALSE)
@@ -2288,7 +2282,7 @@ describe("pipe_set_data",
         dat <- data.frame(a = 1:2, b = 1:2)
 
         pip <- pipe_new("pipe1") |>
-            pipe_add("f1", \(x = ~data) x, keepOut = TRUE)
+            pipe_add("f1", \(x = ~data) x)
 
         out <- pipe_run(pip) |> pipe_collect_out()
         expect_equal(out[["f1"]], NULL)
@@ -2304,8 +2298,8 @@ describe("pipe_set_data",
         dat <- data.frame(a = 1:2, b = 1:2)
 
         pip <- pipe_new("pipe1") |>
-            pipe_add("f1", \(x = ~data) x, keepOut = TRUE) |>
-            pipe_add("f2", \(x = ~f1) x, keepOut = TRUE)
+            pipe_add("f1", \(x = ~data) x) |>
+            pipe_add("f2", \(x = ~f1) x)
 
         pipe_run(pip)
 

--- a/vignettes/v04-collect-output.Rmd
+++ b/vignettes/v04-collect-output.Rmd
@@ -62,8 +62,7 @@ pip <- pipe_new(
             yVar = "Ozone"
         ) {
             data[, c(xVar, yVar)]
-        },
-        keepOut = TRUE              # <- keep this
+        }
     ) |>
 
     pipe_add(
@@ -83,8 +82,7 @@ pip <- pipe_new(
             fit = ~model_fit
         ) {
             summary(fit)
-        },
-        keepOut = TRUE              # <- keep this
+        }
     ) |>
 
     pipe_add(
@@ -101,8 +99,7 @@ pip <- pipe_new(
                 geom_point(aes(.data[[xVar]], .data[["Ozone"]])) +
                 geom_abline(intercept = coeffs[1], slope = coeffs[2]) +
                 labs(title = title)
-        },
-        keepOut = TRUE              # <- keep this
+        }
     )
 ```
 
@@ -111,19 +108,6 @@ Looking at the pipeline, we see that the steps `data_summary`, `model-summary`, 
 
 ```{r}
 pip
-```
-
-```{r, include = nzchar(Sys.getenv("IN_PKGDOWN")), results = "asis", echo = FALSE}
-cat(
-    "Graphically, steps flagged with `keepOut = TRUE` are displayed",
-    "with a circle shape while \"normal\" steps are shown as rectangle boxes."
-)
-```
-
-```{r, echo = FALSE, eval = nzchar(Sys.getenv("IN_PKGDOWN"))}
-library(visNetwork)
-do.call(visNetwork, args = c(pip$get_graph(), list(height = 300))) |>
-    visHierarchicalLayout(direction = "LR", sortMethod = "directed")
 ```
 
 
@@ -168,7 +152,6 @@ pip <- Pipeline$new("my-pipeline", data = airquality) |>
         ) {
             data[, c(xVar, yVar)]
         },
-        keepOut = TRUE,
         group = "Data"                 # <- define 'Data' group here
     ) |>
 
@@ -190,7 +173,6 @@ pip <- Pipeline$new("my-pipeline", data = airquality) |>
         ) {
             summary(fit)
         },
-        keepOut = TRUE,
         group = "Model"                # <- define 'Model' group here
     ) |>
 
@@ -209,7 +191,6 @@ pip <- Pipeline$new("my-pipeline", data = airquality) |>
                 geom_abline(intercept = coeffs[1], slope = coeffs[2]) +
                 labs(title = title)
         },
-        keepOut = TRUE,
         group = "Model"                # <- define 'Model' group here
     )
 ```

--- a/vignettes/v06-self-modify-pipeline.Rmd
+++ b/vignettes/v06-self-modify-pipeline.Rmd
@@ -64,8 +64,7 @@ pip <- pipe_new("my-pipeline") |>
             residuals <- residuals(fit)
             p <- shapiro.test(residuals)$p.value
             p
-        },
-        keepOut = TRUE
+        }
     ) |>
 
     pipe_add(
@@ -81,8 +80,7 @@ pip <- pipe_new("my-pipeline") |>
                 geom_point(shape = 21, color = pointColor) +
                 geom_hline(yintercept = 0, linetype = "dashed") +
                 theme_minimal()
-        },
-        keepOut = TRUE
+        }
     )
 ```
 
@@ -135,8 +133,7 @@ pip$replace_step(
         }
 
         p
-    },
-    keepOut = TRUE
+    }
 )
 ```
 


### PR DESCRIPTION
This pull request refactors the pipeline step metadata to replace the `keepOut` parameter with a new `tags` parameter across the codebase. The `tags` parameter allows associating custom tags with each step, enabling more flexible selection or skipping of steps based on tags. All references to `keepOut` have been removed from both the implementation and documentation, and example code has been updated accordingly.

The most important changes are:

**API and Data Structure Changes:**
* The `keepOut` parameter has been removed from both the `Pipeline` class and related alias functions. Instead, a new `tags` parameter (character vector) is introduced to allow tagging steps for later selection or filtering. All internal uses and documentation of `keepOut` have been replaced with `tags`. [[1]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL154-R161) [[2]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL191-R190) [[3]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1134-R1141) [[4]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1179-R1178) [[5]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1707-R1703) [[6]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L68-R75) [[7]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L878-R884)

**Documentation and Example Updates:**
* All Roxygen and inline code examples have been updated to use the new `tags` parameter instead of `keepOut`. Example outputs now often use `|> str()` to show structure, reflecting modern R idioms. [[1]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL116-R119) [[2]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1115-R1124) [[3]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1232-R1235) [[4]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1245-R1247) [[5]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1405-R1417) [[6]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1547-R1551) [[7]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1573-R1574) [[8]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1648-R1652) [[9]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1669-R1672) [[10]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L27-R30) [[11]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L854-R865) [[12]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L943-R941) [[13]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L957-R955) [[14]](diffhunk://#diff-bdf550be9c2bf2743e9a15bec09e5882bbc96116ca07b4eebf1961c55b3d7d27L1031-R1029)

**Internal Implementation Adjustments:**
* The pipeline's internal data frame and related logic have been updated to store and process `tags` instead of `keepOut`. All code paths that referenced `keepOut` (such as step addition, replacement, and output collection) have been migrated to use the new tagging mechanism or have been simplified. [[1]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL299-R298) [[2]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL386-R386) [[3]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL398-R396) [[4]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL1004-R1002) [[5]](diffhunk://#diff-b91d221201b4ea9d42bc6da02d6a090af813a75ad5d210985390c0fe90392b7eL91-R91)

This update modernizes and generalizes the pipeline step metadata, making it easier to manage and select steps by arbitrary tags rather than a single boolean flag.